### PR TITLE
Properly initialize base from vcs_comm[basedir]

### DIFF
--- a/functions/VCS_INFO_get_data_jj
+++ b/functions/VCS_INFO_get_data_jj
@@ -1,6 +1,7 @@
 setopt localoptions NO_shwordsplit
 
-local action branch base staged unstaged revision misc
+local base=${vcs_comm[basedir]}
+local action branch staged unstaged revision misc
 local _is_working_copy _is_root _is_empty _bookmarks _bookmark_id _parent_id
 
 eval `${vcs_comm[cmd]} log --ignore-working-copy -n 1 --no-graph --color never \


### PR DESCRIPTION
I noticed that that the zsh vcs variables `hook_com[base-name]` and `hook_com[subdir]` were not properly initialized.

It seems that this is related to the local `base` variable in `VCS_INFO_get_data_jj` possibly not being set by one of the evaled `log` commands.

Sine I'm just getting familiar with `jj` I might be missing something.

That said the changes proposed in this PR did fix the aforementioned issue for me.