### PR TITLE
Add change summaries (M/A/D counts), ahead/behind indicators, and conflict markers

### DIFF
--- a/functions/VCS_INFO_get_data_jj
+++ b/functions/VCS_INFO_get_data_jj
@@ -32,4 +32,45 @@ if [[ $_is_root == "true" ]]; then
   branch="root()"
 fi
 
+[[ $action == "conflict" ]] && action='⚡'
+
+if [[ $unstaged == "true" ]]; then
+  local summary m a d changes
+  summary=$(${vcs_comm[cmd]} diff --summary --no-pager --color never 2>/dev/null)
+  read m a d < <(awk '
+    /^M / {m++}
+    /^A / {a++}
+    /^D / {d++}
+    END {print m+0, a+0, d+0}
+  ' <<< "$summary")
+
+  changes=''
+  (( m )) && changes+="M${m}"
+  (( a )) && changes+="${changes:+|}A${a}"
+  (( d )) && changes+="${changes:+|}D${d}"
+  [[ -n $changes ]] && misc="[${changes}]"
+fi
+
+if [[ $_is_root == "false" && -n $_bookmark_id ]]; then
+  local local_ahead
+  local_ahead=$(${vcs_comm[cmd]} log --ignore-working-copy \
+    -r "${_bookmark_id}..@-" --count 2>/dev/null)
+  local_ahead=${local_ahead//[[:space:]]/}
+  (( local_ahead > 0 )) && misc+="${misc:+ }↑${local_ahead}"
+
+  local branch_name="${branch%% *}"
+  if [[ -n $branch_name ]]; then
+    local bm_output ahead behind tracking
+    bm_output=$(${vcs_comm[cmd]} bookmark list --all-remotes "$branch_name" 2>/dev/null)
+    ahead=0; behind=0
+    [[ $bm_output =~ 'ahead by ([0-9]+)' ]] && ahead=$match[1]
+    [[ $bm_output =~ 'behind by ([0-9]+)' ]] && behind=$match[1]
+
+    tracking=''
+    (( ahead > 0 ))  && tracking+="⇡${ahead}"
+    (( behind > 0 )) && tracking+="⇣${behind}"
+    [[ -n $tracking ]] && misc+="${misc:+ }${tracking}"
+  fi
+fi
+
 VCS_INFO_formats "${action}" "${branch}" "${base}" "${staged}" "${unstaged}" "${revision}" "${misc}"

--- a/functions/VCS_INFO_get_data_jj
+++ b/functions/VCS_INFO_get_data_jj
@@ -4,6 +4,7 @@ local base=${vcs_comm[basedir]}
 local action branch staged unstaged revision misc
 local _is_working_copy _is_root _is_empty _bookmarks _bookmark_id _parent_id
 
+# --ignore-working-copy is safe here: bookmarks are persisted state
 eval `${vcs_comm[cmd]} log --ignore-working-copy -n 1 --no-graph --color never \
   -r "coalesce(ancestors(present(@)) & bookmarks(), root())" \
   -T '
@@ -15,7 +16,8 @@ eval `${vcs_comm[cmd]} log --ignore-working-copy -n 1 --no-graph --color never \
     )
   '`
 
-eval `${vcs_comm[cmd]} log --ignore-working-copy -n 1 --no-graph --color never -r "@" \
+# No --ignore-working-copy: forces snapshot so @ reflects on-disk state
+eval `${vcs_comm[cmd]} log -n 1 --no-graph --color never -r "@" \
   -T '
     separate(" ",
       "revision=\"" ++ change_id.shortest() ++ "\"",

--- a/functions/VCS_INFO_get_data_jj
+++ b/functions/VCS_INFO_get_data_jj
@@ -54,7 +54,7 @@ fi
 if [[ $_is_root == "false" && -n $_bookmark_id ]]; then
   local local_ahead
   local_ahead=$(${vcs_comm[cmd]} log --ignore-working-copy \
-    -r "${_bookmark_id}..@-" --count 2>/dev/null)
+    -r "${_bookmark_id}..@" --count 2>/dev/null)
   local_ahead=${local_ahead//[[:space:]]/}
   (( local_ahead > 0 )) && misc+="${misc:+ }↑${local_ahead}"
 

--- a/functions/VCS_INFO_get_data_jj
+++ b/functions/VCS_INFO_get_data_jj
@@ -60,15 +60,17 @@ if [[ $_is_root == "false" && -n $_bookmark_id ]]; then
 
   local branch_name="${branch%% *}"
   if [[ -n $branch_name ]]; then
-    local bm_output ahead behind tracking
+    local bm_output remote_behind remote_ahead tracking
     bm_output=$(${vcs_comm[cmd]} bookmark list --all-remotes "$branch_name" 2>/dev/null)
-    ahead=0; behind=0
-    [[ $bm_output =~ 'ahead by ([0-9]+)' ]] && ahead=$match[1]
-    [[ $bm_output =~ 'behind by ([0-9]+)' ]] && behind=$match[1]
+    remote_behind=0; remote_ahead=0
+    # "behind by N" = remote behind us → we are ahead
+    [[ $bm_output =~ 'behind by ([0-9]+)' ]] && remote_behind=$match[1]
+    # "ahead by N" = remote ahead of us → we are behind
+    [[ $bm_output =~ 'ahead by ([0-9]+)' ]] && remote_ahead=$match[1]
 
     tracking=''
-    (( ahead > 0 ))  && tracking+="⇡${ahead}"
-    (( behind > 0 )) && tracking+="⇣${behind}"
+    (( remote_behind > 0 )) && tracking+="⇡${remote_behind}"
+    (( remote_ahead > 0 ))  && tracking+="⇣${remote_ahead}"
     [[ -n $tracking ]] && misc+="${misc:+ }${tracking}"
   fi
 fi

--- a/zsh-jj.plugin.zsh
+++ b/zsh-jj.plugin.zsh
@@ -18,7 +18,7 @@ zstyle ':vcs_info:git*+set-message:*' hooks git-untracked
 }
 
 zstyle ':vcs_info:*' check-for-changes true
-zstyle ':vcs_info:*:*' formats " %{$fg[blue]%}(%s %{$fg[red]%}%m%u%{$fg[yellow]%}%{$fg[magenta]%} %b%{$fg[blue]%})%{$reset_color%}"
+zstyle ':vcs_info:*:*' formats " %{$fg[blue]%}(%s %{$fg[red]%}%m%{$fg[yellow]%}%{$fg[magenta]%} %b%{$fg[blue]%})%{$reset_color%}"
 
 PROMPT="%B%{$fg[yellow]%}⚡% %(?:%{$fg_bold[green]%}➜ :%{$fg_bold[red]%}➜ )%{$fg[cyan]%}%c%{$reset_color%}"
 PROMPT+="\$vcs_info_msg_0_ "


### PR DESCRIPTION
- `functions/VCS_INFO_get_data_jj`: Populates `%m` with structured change info — `[M3|A1] ↑2 ⇡1⇣2` — showing modified/added/deleted counts, local commits ahead of bookmark, and remote tracking divergence. Conflicts are displayed as `⚡` in the action field.
- `zsh-jj.plugin.zsh`: Drops redundant `%u` from the default format string — unstaged state is now conveyed via `%m`.

All extra subprocesses (`jj diff --summary`, `jj log --count`, `jj bookmark list`) are gated behind the dirty-working-copy and non-root checks, so clean working copies pay no overhead.